### PR TITLE
Introduce a new type of underline/highlighting for style guide alerts

### DIFF
--- a/dependencies/instancebased/connection.js
+++ b/dependencies/instancebased/connection.js
@@ -34,6 +34,7 @@
                 shortAnswer: 'short_answer',
                 disableSpelling: 'disable_spelling',
                 disableGrammar: 'disable_grammar',
+                disableStyleGuide: 'disable_style_guide',
                 version: 'version',
                 locale: 'locale',
                 action: 'action',

--- a/webapi.js
+++ b/webapi.js
@@ -423,6 +423,7 @@
                         customPunctuation: this.getOption('customPunctuation'),
                         minWordLength: this.getOption('minWordLength'),
                         disableGrammar: !this.getOption('enableGrammar') ? true : false,
+                        disableStyleGuide: this.getOption('disableStyleGuide') ? true : false,
                         tokens: parameters.tokens,
                         text: parameters.text
                     },


### PR DESCRIPTION
This PR introduces a new type of underline/highlighting for style guide alerts.

It closes [WP-4882](https://webspellchecker.atlassian.net/browse/WP-4882).