### PR TITLE
Add ability to send Authorization header to the server

### DIFF
--- a/dependencies/instancebased/connection.js
+++ b/dependencies/instancebased/connection.js
@@ -90,6 +90,7 @@
             });
 
             this.withCredentials = appInstance.getOption('withCredentials');
+            this.requestHeaders = appInstance.getOption('requestHeaders');
 
             this.defaultParameters = this.setDefaults(['serviceId', 'communicationFormat', 'appType'], _parametersMap);
         }
@@ -189,6 +190,7 @@
                         .addParameters( this.prepareParameters(parameters, _parametersMap) )
                         .addMetaParameters( this.defaultMetaParameters ),
                     this.withCredentials,
+                    this.requestHeaders,
                     onSuccess,
                     onError
                 );

--- a/dependencies/static/io.js
+++ b/dependencies/static/io.js
@@ -455,7 +455,7 @@
 			 * @param  {Function} onError       Handler unsuccessful response from the server
 			 * @return {String}                 Callback function name
 			 */
-			get: function (url, withCredentials, requestHeaders, onSuccess, onError ) {
+			get: function(url, withCredentials, requestHeaders, onSuccess, onError ) {
 				// Make Request using defined request types
 				return IO.request({
 					url: url,

--- a/dependencies/static/io.js
+++ b/dependencies/static/io.js
@@ -141,13 +141,16 @@
 			 * @param {Object} params Define params that we need
 			 * @param {Object} params.url URL object for this request
 			 * @param {Object} params.withCredentials Flag to determine whether cookies are sent to the server
+			 * @param {Object} params.requestHeaders Function that resolves with an object of request headers
 			 * @param {String} params.onSuccess Handler successful response from the server
 			 * @param {String} params.onError Handler unsuccessful response from the server
 			 * @return {Object} AJAX request custom object
 			 */
 			AJAX: function(params) {
 				var ajax = {},
-					parse = JSON.parse || function() { return arguments };
+					parse = JSON.parse || function() { return arguments },
+					headers = params.requestHeaders() || {},
+					allowedHeaders = { 'Authorization': true };
 
 				if (isMocked) {
 
@@ -228,6 +231,15 @@
 				};
 
 				ajax.request.open('POST', ajax.params.url, true);
+
+				if (Object.keys(headers).length) {
+					for (var header in headers) {
+						if ( allowedHeaders.hasOwnProperty(header) ) {
+							ajax.request.setRequestHeader(header, headers[header]);
+						}
+					}
+				}
+
 				// Fixed IE9 bug with ajax requests.
 				if (Utils.Browser.ie && Utils.Browser.version === 9) {
 					setTimeout(function() {
@@ -438,15 +450,17 @@
 			 * Create request on server
 			 * @param  {Object} url             Object created with params
 			 * @param  {Object} withCredentials Flag to determine whether cookies are sent to the server
+			 * @param  {Object} requestHeaders  Function that resolves with an object of request headers
 			 * @param  {Function} onSuccess     Handler successful response from the server
 			 * @param  {Function} onError       Handler unsuccessful response from the server
 			 * @return {String}                 Callback function name
 			 */
-			get: function( url, withCredentials, onSuccess, onError ) {
+			get: function (url, withCredentials, requestHeaders, onSuccess, onError ) {
 				// Make Request using defined request types
 				return IO.request({
 					url: url,
 					withCredentials: withCredentials,
+					requestHeaders: requestHeaders,
 					onSuccess: onSuccess,
 					onError: onError
 				});

--- a/webapi.js
+++ b/webapi.js
@@ -72,6 +72,10 @@
             withCredentials: {
                 type: optionTypes.boolean,
                 defaultValue: false
+            },
+            requestHeaders: {
+                type: optionTypes.function,
+                defaultValue: function() {}
             }
         };
 


### PR DESCRIPTION
This PR adds ability to send Authorization header to the server.

It closes [WP-5572](https://webspellchecker.atlassian.net/browse/WP-5572).