### PR TITLE
Add checkKit field to the statistics requests

### DIFF
--- a/webapi.js
+++ b/webapi.js
@@ -620,6 +620,7 @@
                     language: parameters.lang || this.getOption('lang'),
                     detectedLang: parameters.detectedLang,
                     enforceAI: parameters.enforceAI || this.getOption('enforceAI'),
+                    checkKit: this.getOption('checkKit'),
                     type: parameters.type,
                     category: parameters.category,
                     rule: parameters.rule || '',


### PR DESCRIPTION
This PR adds checkKit field to the statistics requests.

It partially closes [WP-6058](https://webspellchecker.atlassian.net/browse/WP-6058).

[WP-6058]: https://webspellchecker.atlassian.net/browse/WP-6058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ