### PR TITLE
Add responseTime field to the statistics requests

### DIFF
--- a/dependencies/instancebased/connection.js
+++ b/dependencies/instancebased/connection.js
@@ -49,7 +49,8 @@
                 prompt: 'prompt',
                 suggestions: 'suggestions',
                 checkKit: 'check_kit',
-                probability: 'probability'
+                probability: 'probability',
+                responseTime: 'response_time'
             },
             _commandsMap = {
                 spellCheck: 'check_spelling',

--- a/webapi.js
+++ b/webapi.js
@@ -628,7 +628,8 @@
                     context: parameters.context,
                     prompt: parameters.prompt,
                     suggestions: parameters.suggestions,
-                    probability: parameters.probability
+                    probability: parameters.probability,
+                    responseTime: parameters.responseTime
                 },
                     parameters
                 );


### PR DESCRIPTION
This PR adds responseTime field to the statistics requests.

It closes [WP-6283](https://webspellchecker.atlassian.net/browse/WP-6283).

[WP-6283]: https://webspellchecker.atlassian.net/browse/WP-6283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ