### PR TITLE
Add containerType field to the getInfo requests

### DIFF
--- a/dependencies/instancebased/connection.js
+++ b/dependencies/instancebased/connection.js
@@ -50,7 +50,8 @@
                 suggestions: 'suggestions',
                 checkKit: 'check_kit',
                 probability: 'probability',
-                responseTime: 'response_time'
+                responseTime: 'response_time',
+                containerType: 'container_type'
             },
             _commandsMap = {
                 spellCheck: 'check_spelling',

--- a/webapi.js
+++ b/webapi.js
@@ -233,7 +233,8 @@
                 return this._request({
                         command: this._commands.getInfo,
                         locale: parameters.locale || this.getOption('localization'),
-                        version: parameters.version || 2
+                        version: parameters.version || 2,
+                        containerType: this.getOption('containerType')
                     },
                     parameters
                 );


### PR DESCRIPTION
This PR adds containerType field to the getInfo requests.

It closes [WP-5907](https://webspellchecker.atlassian.net/browse/WP-5907).

[WP-5907]: https://webspellchecker.atlassian.net/browse/WP-5907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ